### PR TITLE
Metacommunity is now Regio Aachen

### DIFF
--- a/acffapi.json
+++ b/acffapi.json
@@ -1,7 +1,7 @@
 {
     "name": "Freifunk Aachen",
     "url": "http://www.Freifunk-Aachen.de",
-    "metacommunity": "Freifunk Rheinland e.V.",
+    "metacommunity": "Freifunk Regio Aachen",
     "location": {
         "city": "Aachen",
         "country": "DE",


### PR DESCRIPTION
Die anderen Domänen wie Freifunk Ruhrgebiet, Freifunk Möhne setzen als Metacommunity nicht den Freifunk Rheinland e.V.

Projekte wie die Freifunkkarte in [diesem Forumsthread](https://forum.freifunk.net/t/freifunk-landkarte/5181) nutzen die Metacommunity-Angabe. Daher werden wir mit der Domäne Rheinufer zusammengeworfen.

Dieser PR setzt daher die metacommunity auf "Freifunk Regio Aachen".

Unsere Zugehörigkeit zum Freifunk Rheinland e.V. wird immer noch über das support/clubs Attribut ausgedrückt.

Wenn wir diesen PR mergen sollten wir die Info auch an unsere anderen angeschlossenen Communities weiterleiten. Das wären laut API-Directory im Moment Düren und Jülich, kann aber sein, dass ich jemanden übersehen habe.
