### PR TITLE
[REQUEST FOR COMMENTS] Write nodelist.json (created from hopglass) into API-file for use by freifunk-karte.de

### DIFF
--- a/acffapi.json
+++ b/acffapi.json
@@ -40,6 +40,11 @@
             "url": "http://map.freifunk-aachen.de/",
             "interval": "1 minute",
             "technicalType": "meshviewer"
+        },
+        {
+            "url": "http://data.aachen.freifunk.net/nodelist.json",
+            "interval": "1 minute",
+            "technicalType": "nodelist"
         }
     ],
     "support": {

--- a/acffapi.json
+++ b/acffapi.json
@@ -16,7 +16,7 @@
         "webform": "http://freifunk-aachen.de/kontakt/"
     },
     "state": {
-        "nodes": 970,
+        "nodes": 1220,
         "description": "Die Community Aachen ist die Anlaufstelle für Freifunk in Aachen, der StädteRegion und Umgebung.",
         "focus": [
             "infrastructure/backbone",


### PR DESCRIPTION
This pull request adds a nodelist.json that was created from hopglass into our API file.
# Why offering redundant information?

nodelist is a special format for freifunk-karte.de that always gets precedence over other maps offered.
This change will become a first step towards refactoring the mapping of the Regio Aachen "sphere of influence" onto the API.
# Why is refactoring necessary?

Unfortunately the API does not really model the idea of "Meta-Communities" like the domain Regio Aachen all too well. AFAIK the maintainers of the API have decided not to add any more "Meta-Communities" to the API (because it is not decantralized and the API file maintainer of such a meta-community has too much power over the poor communities on town level to bend them to the metacommunity's will, which has of course happened all the time <sub>no, it didn't</sub> and is obviously literally fascism™ <sub>no it's not</sub>), only existing ones like Ruhrgebiet or FFNord may stay to avoid breaking stuff.

In the future, the guideline "One city -> One community" will be enforced in the API directory. So we need to invest some work to clean up our data sources and work around this.

Right now, there are already a couple of Regio Aachen communities in the API directory. (Right now, it's Aachen and Düren, the past entry for Jülich has apperantly been removed, presumably over this confusion...?)
Among these, the community at Aachen acts like a "Meta-Community" as a sorts which has following disadvantages:
- The (equally active) communities at towns within the Regio Aachen are not represented in the freifunk.net community finder at all. The community finder is still prominently placed at Google and the recommended a way (e.g. by official publications of mabb or state of NRW) to check for existence of communities at a certain city. It is possible that deciders e.g. at town councils might assume that there is little sustainable Freifunk activity within their city when in fact the community is pretty active.
- If a Regio Aachen community decides to get an API entry and includes a node count estimate, these are double-counted in many statistics.
- Aggregators like freifunk-karte.de have clunky hacks if a data source (map) is used multiple times within the API directory which has already caused problems.
# The plan

As noted above the nodelist format (and its priority treatment by aggregators like freifunk-karte.de) provides us with a means to solve the conundrum in the following manner:
- We decide on the borders of our sphere of influence. Obviously we should do this in consensus with bordering communities (from the top of my head: Freifunk Ruhrgebiet, Freifunk Rhein-Erft, KBU, Freifunk Euskirchen) so we don't step on toes here.
- We do a census and find all communities within our sphere of influence that are to be considered active. Each of them should get an API directory entry. If no manpower/knowledge for maintaining an API file is available (but seriously, it's easy and almost no work, _Arsch huh!_), the file can be maintained by the Regio Aachen admin team.
- We partition our sphere of influence geographically. Then we filter all nodes with geographical data according to these borders. For simplicity I would recommend to take the individual city limits as smallest unit. If no community is active within a city, a nearby community should "claim" this city (just for purpose of statistics), no city must remain "unclaimed" to have all nodes accounted for. This procedure causes less hassle with repartitioning if a new community starts to become active in a previously inactive city.
  NOTE: The partitioning is intentionally different from the segmentation partitioning for that reason.
- The existing GIS scripts can be used to partition the set of nodes according to these borders. It is up to debate whether position of geo-untagged nodes should be inferred by mesh links or if a simple approach which ignores mesh should be used.
- Nodes with no geo coordinates or outside of the Regio Aachen sphere of influence should either be discarded (causing a drop in statistics for all of NRW/Germany) or silently counted for the city of Aachen (slightly inflating the statistics within this city (:laughing:) , but keeping large-scale statistics intact)
# Future steps necessary
- Test that nodelist behaves as expected (DONE when this PR is merged, once freifunk-karte.de becomes aware of the nodelist and starts parsing it, diagnostics become available)
- Implement the partitioning of nodes. (Probably segmenter logic can be reused). I can do that.
- Reach out to bordering communities and inform them which towns we would like to "claim". Make sure that this is only for purpose of statistics and also not set in stone, so we don't start flame wars...
- Reach out to all communities within Regio Aachen, inform them of the problem, and try to reach a consensus that this plan is a good idea.
# Will this PR break things?

First off: Only the node listings of freifunk-karte.de (and downstream data users like the Freifunk app) are affected. Our map will still work no matter what.

If the nodelist.json becomes corrupted or unavailable for some reason, freifunk-karte.de should fall back to our map as data source.

If all fails, we can restore original behavior quickly by reverting this PR.
