### PR TITLE
Feed-URLS auf https umgestellt

### DIFF
--- a/acffapi.json
+++ b/acffapi.json
@@ -32,13 +32,13 @@
             "name": "Freifunk Aachen News",
             "category": "blog",
             "type": "RSS",
-            "url": "http://freifunk-aachen.de/feed/"
+            "url": "https://freifunk-aachen.de/feed/"
         },
         {
             "name": "Freifunk Aachen Termine",
             "category": "ics",
             "type": "ics",
-            "url": "http://freifunk-aachen.de/?plugin=all-in-one-event-calendar&controller=ai1ec_exporter_controller&action=export_events&no_html=true"
+            "url": "https://freifunk-aachen.de/?plugin=all-in-one-event-calendar&controller=ai1ec_exporter_controller&action=export_events&no_html=true"
         }
     ],
     "nodeMaps": [


### PR DESCRIPTION
Die RSS- und ICS-Feeds auf freifunk-aachen.de sind nicht mehr per http erreichbar, dort kommt nur ein Redirect auf die https-Seite.